### PR TITLE
More flexible parameter printing in get_param

### DIFF
--- a/PythonCLI/gree.py
+++ b/PythonCLI/gree.py
@@ -139,7 +139,8 @@ def get_param():
 
         pack_decrypted = decrypt(pack, args.key)
         pack_json = json.loads(pack_decrypted)
-        print('%s = %s' % (args.param, pack_json['dat'][0]))
+        for col, dat in zip(pack_json['cols'], pack_json['dat']):
+            print('%s = %s' % (col, dat))
 
 
 def set_param():


### PR DESCRIPTION
Enables printing more than one element in response and avoids `IndexError: list index out of range` if there's no element.